### PR TITLE
Fix bug when using CarrierWaveDirect for some uploaders but not others

### DIFF
--- a/lib/carrierwave_direct/orm/activerecord.rb
+++ b/lib/carrierwave_direct/orm/activerecord.rb
@@ -10,6 +10,8 @@ module CarrierWaveDirect
     def mount_uploader(column, uploader=nil, options={}, &block)
       super
 
+      return unless uploader.ancestors.include?(CarrierWaveDirect::Uploader)
+
       uploader.instance_eval <<-RUBY, __FILE__, __LINE__+1
         include ActiveModel::Conversion
         extend ActiveModel::Naming


### PR DESCRIPTION
Don't monkeypatch the uploader for activerecord unless CarrierWaveDirect has been included.

Without this change, having some uploaders that use CarrierWaveDirect and others that do not, fails miserably.
