### PR TITLE
Allow custom field for policy

### DIFF
--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -395,6 +395,12 @@ describe CarrierWaveDirect::Uploader do
             ).should have_content_length_range(sample(:max_file_size))
           end
         end
+
+        it "any customisable fields that S3 should ignore" do
+          conditions(
+            :ignore_fields => [:field_auto_added_by_framwork_x]
+          ).should have_condition(:field_auto_added_by_framwork_x)
+        end
       end
     end
   end


### PR DESCRIPTION
Hi

I'm using the plugin with uploadify, which (unless you configure it to) does not include a field called `utf8` but does send some additional fields that I have no control over (`folder` and `filename`). These fields when included, cause S3 to error because they are not defined in the policy.

My change allows you to pass an option `:ignore_fields` to the `policy` and `signature` methods, that will define additional fields in the policy. By default the array of ignored fields is just `[:utf8]` to support a standard Rails form.
