### PR TITLE
FIX: URIBadComponent error with caused bye filename characters not being escaped.

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -23,8 +23,6 @@ module CarrierWaveDirect
       def direct_fog_url(options = {})
         fog_uri = CarrierWave::Storage::Fog::File.new(self, CarrierWave::Storage::Fog.new(self), nil).public_url
         if options[:with_path]
-          Rails.logger.debug(fog_uri.inspect)
-          Rails.logger.debug(key)
           uri = URI.parse(fog_uri)
           path = "/#{key}"
           uri.path = URI.escape(path)


### PR DESCRIPTION
When unsafe URI characters appeared in file names it would cause jobs to fail. Specifically when calling direct_fog_url(:with_path => true).

The ruby URI library throws URI::InvalidComponentError. The fix is done by simply calling URI.escape on the path string.
