### PR TITLE
Remove UUID

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -31,7 +31,7 @@ module CarrierWaveDirect
         fog_uri
       end
 
-      def guid
+      def guid #can be deprecated
         UUID.generate
       end
 
@@ -41,7 +41,7 @@ module CarrierWaveDirect
       end
 
       def key
-        @key ||= "#{store_dir}/#{guid}/#{FILENAME_WILDCARD}"
+        @key ||= "#{store_dir}/#{FILENAME_WILDCARD}"
       end
 
       def has_key?


### PR DESCRIPTION
I didn't want to work with UUID to preserve readibility at S3 level. I think many people will have the same need so I propose to keep this away of the gem and to leave the choice to work with UUID at application level, in the uploader settings
