### PR TITLE
S3 was rejecting Time.now.utc as a time format

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -57,7 +57,7 @@ module CarrierWaveDirect
 
       Base64.encode64(
         {
-          'expiration' => Time.now.utc + options[:expiration],
+          'expiration' => (Time.now + options[:expiration]).utc.iso8601,
           'conditions' => [
             ["starts-with", "$utf8", ""],
             ["starts-with", "$key", store_dir],


### PR DESCRIPTION
Using carrierwave_direct out of the box with sinatra I was getting:

Invalid Policy: Invalid 'expiration' value
at upload time from S3

When changing the policy method to use Time.now.utc.iso8601 instead the uploads work. 
