### PR TITLE
Fix carrierwave_direct for carrierwave 0.6.0 on s3_access_policy

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -48,7 +48,7 @@ module CarrierWaveDirect
     end
 
     def acl
-      s3_access_policy.to_s.gsub('_', '-')
+      fog_public ? 'public-read' : 'private'
     end
 
     def policy(options = {})

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -300,8 +300,8 @@ describe CarrierWaveDirect::Uploader do
   end
 
   describe "#acl" do
-    it "should return the sanitized s3 access policy" do
-      subject.acl.should == subject.s3_access_policy.to_s.gsub("_", "-")
+    it "should return the correct s3 access policy" do
+      subject.acl.should == (subject.fog_public ? 'public-read' : 'private')
     end
   end
 


### PR DESCRIPTION
Carrierwave 0.6.0 no longer provides s3_access_policy I think because of the move to exclusively using fog. Not sure if this is the best way to handle it, but I couldn't find a method in fog to call to retrieve the aws access policy. However, when fog_public is set to true, this is how fog sets the access policy of new files.

This seems to fix carrierwave_direct with version 0.6.0 for me, although it may still be missing something.
