### PR TITLE
CarrierWaveDirect validators added to the ActiveRecord class even if the uploader is a standard CarrierWave uploader

### DIFF
--- a/lib/carrierwave_direct/orm/activerecord.rb
+++ b/lib/carrierwave_direct/orm/activerecord.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 
+# This file tests that a ActiveRecord class that uses a standard CarrierWave uploader
+# does not get CarrierWaveDirect validators.
+
 require 'active_record'
 require 'carrierwave_direct/validations/active_model'
 
@@ -9,6 +12,9 @@ module CarrierWaveDirect
 
     def mount_uploader(column, uploader=nil, options={}, &block)
       super
+
+      # Don't go further unless the class included CarrierWaveDirect::Uploader
+      return unless uploader.ancestors.include?(CarrierWaveDirect::Uploader)
 
       uploader.instance_eval <<-RUBY, __FILE__, __LINE__+1
         include ActiveModel::Conversion

--- a/spec/orm/indirect_activerecord_spec.rb
+++ b/spec/orm/indirect_activerecord_spec.rb
@@ -1,0 +1,68 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'carrierwave/orm/activerecord'
+require 'carrierwave_direct/orm/activerecord'
+
+describe CarrierWave::ActiveRecord do
+  dbconfig = {
+    :adapter => 'sqlite3',
+    :database => ':memory:'
+  }
+
+  class OtherTestMigration < ActiveRecord::Migration
+    def self.up
+      create_table :other_parties, :force => true do |t|
+        t.column :video, :string
+      end
+    end
+
+    def self.down
+      drop_table :other_parties
+    end
+  end
+
+  class StandardUploader < CarrierWave::Uploader::Base
+  end
+
+  class OtherParty < ActiveRecord::Base
+    # mount_uploader :video, StandardUploader
+  end
+
+  ActiveRecord::Base.establish_connection(dbconfig)
+
+  # turn off migration output
+  ActiveRecord::Migration.verbose = false
+
+  before(:all) { OtherTestMigration.up }
+  after(:all) { OtherTestMigration.down }
+  after { OtherParty.delete_all }
+
+  describe "class OtherParty < ActiveRecord::Base; mount_uploader :video, StandardUploader; end" do
+    $arclass = 0
+
+    let(:party_class) do
+      Class.new(OtherParty)
+    end
+
+    let(:subject) do
+      party = party_class.new
+    end
+
+    before do
+      # see https://github.com/jnicklas/carrierwave/blob/master/spec/orm/activerecord_spec.rb
+      $arclass += 1
+      Object.const_set("OtherParty#{$arclass}", party_class)
+      party_class.table_name = "other_parties"
+    end
+
+    describe "#mount_uploader" do
+      it "does not inject CarrierWaveDirect validation into ActiveRecord class" do
+        subject.class.mount_uploader :video, StandardUploader
+
+        subject.class.ancestors.should_not include(CarrierWaveDirect::Validations::ActiveModel)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
I ran into the same issue as Amiel Martin when using standard CarrierWave uploaders alongside CarrierWaveDirect uploaders:

```
NoMethodError (undefined method `has_key?' for :DocumentFileUploader):
```

The problem is that `#mount_uploader` injects CarrierWaveDirect validators into the ActiveRecord class, even when the uploader is not a CarrierWaveDirect uploader.

I wrote a spec for the problem and implemented Amiel's fix.
