### PR TITLE
Do not modify the class with CarrierWaveDirect-specific methods

### DIFF
--- a/lib/carrierwave_direct/mount.rb
+++ b/lib/carrierwave_direct/mount.rb
@@ -6,6 +6,9 @@ module CarrierWaveDirect
     def mount_uploader(column, uploader=nil, options={}, &block)
       super
 
+      # Don't go further unless the class included CarrierWaveDirect::Uploader
+      return unless uploader.ancestors.include?(CarrierWaveDirect::Uploader)
+
       uploader.class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}; self; end
       RUBY

--- a/spec/orm/indirect_activerecord_spec.rb
+++ b/spec/orm/indirect_activerecord_spec.rb
@@ -62,6 +62,12 @@ describe CarrierWave::ActiveRecord do
 
         subject.class.ancestors.should_not include(CarrierWaveDirect::Validations::ActiveModel)
       end
+
+      it "does not modify the class with CarrierWaveDirect-specific methods" do
+        subject.class.mount_uploader :video, StandardUploader
+
+        subject.methods.should_not include(:has_video_upload?)
+      end
     end
   end
 end


### PR DESCRIPTION
Prevents CarrierWaveDirect::Mount#mount_uploader from adding methods to
an ActiveRecord class that does not include CarrierWaveDirect::Uploader
