### PR TITLE
Small README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ CarrierWaveDirect works with [fog](https://github.com/geemus/fog) so make sure y
         :aws_secret_access_key  => 'yyy',       # required
         :region                 => 'eu-west-1'  # optional, defaults to 'us-east-1'
       }
-      config.fog_directory  = 'name_of_directory'                     # required
+      config.fog_directory  = 'name_of_your_aws_bucket' # required
       # see https://github.com/jnicklas/carrierwave#using-amazon-s3
       # for more optional configuration
     end


### PR DESCRIPTION
Hi, I was not sure what the directory value should be, but later on in the readme it becomes clear it should be the aws bucket name.

So I updated this in the examples, making it hopefully more clear one should declare their bucket name overthere.
