### PR TITLE
Stop urls from double encoding on subsequent saves

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -42,7 +42,7 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if url.present?
-        self.key = URI.parse(url).path # explicitly set key
+        self.key = CGI.unescape(URI.parse(url).path) # explicitly set key
       else
         @key = "#{store_dir}/#{guid}/#{FILENAME_WILDCARD}"
       end


### PR DESCRIPTION
If you have a file which needs to have characters encoded to make a proper url (files with spaces for example) they get encoded every time the model saves. This causes some files to be encoded after being encoded, which creates incorrect urls. 

In other words, if a file has characters that need to be url encoded, and that model is saved after the file has been uploaded, the file name is stored wrong in the AR column.

This quick fix fixes that.
