### PR TITLE
New configuration parameter: min_file_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ As well as the built in validations CarrierWaveDirect provides, some validations
       config.validate_filename_format = false        # defaults to true
       config.validate_remote_net_url_format = false  # defaults to true
 
+      config.min_file_size     = 5.kilobytes         # defaults to 1.byte
       config.max_file_size     = 10.megabytes        # defaults to 5.megabytes
       config.upload_expiration = 1.hour              # defaults to 10.hours
     end

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -59,6 +59,7 @@ module CarrierWaveDirect
 
     def policy(options = {})
       options[:expiration] ||= self.class.upload_expiration
+      options[:min_file_size] ||= self.class.min_file_size
       options[:max_file_size] ||= self.class.max_file_size
 
       Base64.encode64(
@@ -71,7 +72,7 @@ module CarrierWaveDirect
             {"bucket" => fog_directory},
             {"acl" => acl},
             {"success_action_redirect" => success_action_redirect},
-            ["content-length-range", 1, options[:max_file_size]]
+            ["content-length-range", options[:min_file_size], options[:max_file_size]]
           ]
         }.to_json
       ).gsub("\n","")

--- a/lib/carrierwave_direct/uploader/configuration.rb
+++ b/lib/carrierwave_direct/uploader/configuration.rb
@@ -13,6 +13,7 @@ module CarrierWaveDirect
         add_config :validate_filename_format
         add_config :validate_remote_net_url_format
 
+        add_config :min_file_size
         add_config :max_file_size
         add_config :upload_expiration
         reset_direct_config
@@ -27,6 +28,7 @@ module CarrierWaveDirect
             config.validate_filename_format = true
             config.validate_remote_net_url_format = true
 
+            config.min_file_size = 1
             config.max_file_size = 5242880
             config.upload_expiration = 36000
           end


### PR DESCRIPTION
Currently, 1 is hardcoded as minimum file size. This causes problems when submitting without specifying a file -- an ugly XML error page is presented.
This change allows setting 0 as the minimum size to avoid this.
