### PR TITLE
Failure in Uploader.direct_fog_url

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -23,8 +23,8 @@ module CarrierWaveDirect
       fog_uri = CarrierWave::Storage::Fog::File.new(self, CarrierWave::Storage::Fog.new(self), nil).public_url
       if options[:with_path]
         uri = URI.parse(fog_uri)
-        path = "/#{key}"
-        uri.path = URI.escape(path)
+        path = "#{key}"
+        uri.path += URI.escape(path)
         fog_uri = uri.to_s
       end
       fog_uri

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -241,7 +241,10 @@ describe CarrierWaveDirect::Uploader do
         before { subject.key = sample(:path_with_special_chars) }
 
         it "should return the full url with '/#{URI.escape(sample(:path_with_special_chars))}' as the path" do
-          URI.parse(subject.direct_fog_url(:with_path => true)).path.should == "/#{URI.escape(sample(:path_with_special_chars))}"
+          direct_fog_url = CarrierWave::Storage::Fog::File.new(
+            subject, nil, nil
+          ).public_url
+          subject.direct_fog_url(:with_path => true).should == direct_fog_url + "#{URI.escape(sample(:path_with_special_chars))}"
         end
       end
 
@@ -249,7 +252,10 @@ describe CarrierWaveDirect::Uploader do
         before { subject.key = sample(:path) }
 
         it "should return the full url with '/#{sample(:path)}' as the path" do
-          URI.parse(subject.direct_fog_url(:with_path => true)).path.should == "/#{sample(:path)}"
+          direct_fog_url = CarrierWave::Storage::Fog::File.new(
+            subject, nil, nil
+          ).public_url
+          subject.direct_fog_url(:with_path => true).should == direct_fog_url + "#{sample(:path)}"
         end
       end
     end


### PR DESCRIPTION
Hey!

I found a failure in the direct_fog_path [uplader.rb#L22-L31](https://github.com/dwilkie/carrierwave_direct/blob/master/lib/carrierwave_direct/uploader.rb#L22-L31)

The error is even located in the tests. A quick dump after this line [uploader_spec.rb#L244](https://github.com/dwilkie/carrierwave_direct/blob/master/spec/uploader_spec.rb#L244) and [uploader_spec.rb#L252](https://github.com/dwilkie/carrierwave_direct/blob/master/spec/uploader_spec.rb#L252) gave me the following results:

```
subject.direct_fog_url =                     https://s3.amazonaws.com/AWS_FOG_DIRECTORY/
subject.direct_fog_url(:with_path => true) = https://s3.amazonaws.com/upload_dir/some%20file%20&%20blah.exe

subject.direct_fog_url =                     https://s3.amazonaws.com/AWS_FOG_DIRECTORY/
subject.direct_fog_url(:with_path => true) = https://s3.amazonaws.com/upload_dir/bliind.exe`
```

It removes the AWS_FOG_DIRECTLY information from the URL and thus creating an invalid URL.

So i changed several things (including the tests) and voilà:

```
subject.direct_fog_url =                     https://s3.amazonaws.com/AWS_FOG_DIRECTORY/
subject.direct_fog_url(:with_path => true) = https://s3.amazonaws.com/AWS_FOG_DIRECTORY/upload_dir/some%20file%20&%20blah.exe

subject.direct_fog_url =                     https://s3.amazonaws.com/AWS_FOG_DIRECTORY/
subject.direct_fog_url(:with_path => true) = https://s3.amazonaws.com/AWS_FOG_DIRECTORY/upload_dir/bliind.exe`
```

And even if I set the config.fog_directory to something AWS "valid" (meaning including only numbers, letters and dashes), it will produce the right url an the tests will pass:

```
https://aws-fog.s3.amazonaws.com/upload_dir/bliind.exe
```
