### PR TITLE
lazy load UUID

### DIFF
--- a/lib/carrierwave_direct.rb
+++ b/lib/carrierwave_direct.rb
@@ -4,7 +4,8 @@ require "carrierwave_direct/version"
 
 require "carrierwave"
 require "fog"
-require "uuid"
+
+autoload :UUID, "uuid"
 
 module CarrierWaveDirect
 


### PR DESCRIPTION
we're using carrierwave_direct with a JRuby application hosted on Heroku. requiring "uuid" caused serious boot time issue so we're just lazy loading it.

thanks for considering this pull request!
