### PR TITLE
Fix: Sometimes, esp. in tests, a double-slash occurs in the direct_fog_url

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -22,8 +22,8 @@ module CarrierWaveDirect
     def direct_fog_url(options = {})
       fog_uri = CarrierWave::Storage::Fog::File.new(self, CarrierWave::Storage::Fog.new(self), nil).public_url
       if options[:with_path]
-        uri = URI.parse(fog_uri)
-        path = "#{key}"
+        uri = URI.parse(fog_uri.chomp('/'))
+        path = "/#{key}"
         uri.path += URI.escape(path)
         fog_uri = uri.to_s
       end


### PR DESCRIPTION
This results in a 403 and means that the file can't be accessed.
From what I can tell, it results from the file's path being nil,
like when someone `store!`s a file manually in a test.
