### PR TITLE
remove initial slash from existing keys. References #74

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -42,7 +42,7 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if url.present?
-        self.key = URI.parse(URI.encode(url)).path # explicitly set key
+        self.key = URI.parse(URI.encode(url)).path[1 .. -1] # explicitly set key
       else
         @key = "#{store_dir}/#{guid}/#{FILENAME_WILDCARD}"
       end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -123,12 +123,12 @@ describe CarrierWaveDirect::Uploader do
           mounted_subject.stub(:url).and_return(sample(:s3_file_url))
         end
 
-        it "should return '/#{sample(:s3_key)}'" do
-          mounted_subject.key.should == "/#{sample(:s3_key)}"
+        it "should return '#{sample(:s3_key)}'" do
+          mounted_subject.key.should == sample(:s3_key)
         end
 
         it "should set the key explicitly in order to update the version keys" do
-          mounted_subject.should_receive("key=").with("/#{sample(:s3_key)}")
+          mounted_subject.should_receive("key=").with(sample(:s3_key))
           mounted_subject.key
         end
       end
@@ -434,7 +434,7 @@ describe CarrierWaveDirect::Uploader do
           subject.success_action_redirect = "http://example.com/some_url"
           conditions.should have_condition("success_action_redirect" => "http://example.com/some_url")
         end
-        
+
         it "'content-type' only if enabled" do
           conditions.should have_condition('Content-Type') if subject.class.will_include_content_type
         end


### PR DESCRIPTION
As mentioned on #74, I'm not 100% sure about this change, since I had to change two existing tests which explicitly required a slash at the beginning of the keys. I think there is a good change (about 80%) that this was a mistake. But it could also be due to some reason I ignore. So pick this pull request with caution.

In any case, I can confirm that after the change, things seem to be working on my end. Before it, Amazon plain refused to update files because of this.

Cheers!
