### PR TITLE
Added feature to disable success_action_redirect and use success_action_status instead

### DIFF
--- a/lib/carrierwave_direct/form_builder.rb
+++ b/lib/carrierwave_direct/form_builder.rb
@@ -4,13 +4,19 @@ module CarrierWaveDirect
   class FormBuilder < ActionView::Helpers::FormBuilder
     def file_field(method, options = {})
       options.merge!(:name => "file")
-      hidden_field(:key,                             :name => "key") <<
-      hidden_field(:aws_access_key_id,               :name => "AWSAccessKeyId") <<
-      hidden_field(:acl,                             :name => "acl") <<
-      hidden_field(:success_action_redirect,         :name => "success_action_redirect") <<
-      hidden_field(:policy,                          :name => "policy") <<
-      hidden_field(:signature,                       :name => "signature") <<
-      super
+      fields = hidden_field(:key, :name => "key")
+      fields << hidden_field(:aws_access_key_id, :name => "AWSAccessKeyId")
+      fields << hidden_field(:acl, :name => "acl")
+      fields << hidden_field(:policy, :name => "policy")
+      fields << hidden_field(:signature, :name => "signature")
+
+      if options[:use_action_status]
+        fields << hidden_field(:success_action_status, :name => "success_action_status")
+      else
+        fields << hidden_field(:success_action_redirect, :name => "success_action_redirect")
+      end
+
+      fields << super
     end
   end
 end

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -11,6 +11,7 @@ module CarrierWaveDirect
       storage :fog
 
       attr_accessor :success_action_redirect
+      attr_accessor :success_action_status
 
       fog_credentials.keys.each do |key|
         define_method(key) do
@@ -67,16 +68,21 @@ module CarrierWaveDirect
         ["starts-with", "$key", key.sub(/#{Regexp.escape(FILENAME_WILDCARD)}\z/, "")]
       ]
       conditions << ["starts-with", "$Content-Type", ""] if self.class.will_include_content_type
+      conditions << {"bucket" => fog_directory}
+      conditions << {"acl" => acl}
+
+      if self.class.use_action_status
+        conditions << {"success_action_status" => success_action_status}
+      else
+        conditions << {"success_action_redirect" => success_action_redirect}
+      end
+
+      conditions << ["content-length-range", options[:min_file_size], options[:max_file_size]]
 
       Base64.encode64(
         {
           'expiration' => Time.now.utc + options[:expiration],
-          'conditions' => conditions + [
-            {"bucket" => fog_directory},
-            {"acl" => acl},
-            {"success_action_redirect" => success_action_redirect},
-            ["content-length-range", options[:min_file_size], options[:max_file_size]]
-          ]
+          'conditions' => conditions
         }.to_json
       ).gsub("\n","")
     end

--- a/lib/carrierwave_direct/uploader/configuration.rb
+++ b/lib/carrierwave_direct/uploader/configuration.rb
@@ -17,6 +17,9 @@ module CarrierWaveDirect
         add_config :max_file_size
         add_config :upload_expiration
         add_config :will_include_content_type
+
+        add_config :use_action_status
+
         reset_direct_config
       end
 
@@ -32,6 +35,8 @@ module CarrierWaveDirect
             config.min_file_size = 1
             config.max_file_size = 5242880
             config.upload_expiration = 36000
+
+            config.use_action_status = false
           end
         end
       end

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -7,11 +7,15 @@ describe CarrierWaveDirect::FormBuilder do
 
   describe "#file_field" do
 
-    def form_with_file_field
+    def form_with_default_file_field
       form {|f| f.file_field :video }
     end
 
-    hidden_fields = [
+    def form_with_file_field_and_no_redirect
+      form {|f| f.file_field :video, use_action_status: true }
+    end
+
+    default_hidden_fields = [
                       :key,
                       {:aws_access_key_id => "AWSAccessKeyId"},
                       :acl,
@@ -19,11 +23,19 @@ describe CarrierWaveDirect::FormBuilder do
                       :policy,
                       :signature
                     ]
+    status_hidden_fields = [
+                      :key,
+                      {:aws_access_key_id => "AWSAccessKeyId"},
+                      :acl,
+                      :success_action_status,
+                      :policy,
+                      :signature
+                    ]
 
     # http://aws.amazon.com/articles/1434?_encoding=UTF8
     context "form" do
 
-      hidden_fields.each do |input|
+      default_hidden_fields.each do |input|
         if input.is_a?(Hash)
           key = input.keys.first
           name = input[key]
@@ -33,7 +45,28 @@ describe CarrierWaveDirect::FormBuilder do
 
         it "should have a hidden field for '#{name}'" do
           direct_uploader.stub(key).and_return(key.to_s)
-          form_with_file_field.should have_input(
+          form_with_default_file_field.should have_input(
+            :direct_uploader,
+            key,
+            :type => :hidden,
+            :name => name,
+            :value => key,
+            :required => false
+          )
+        end
+      end
+
+      status_hidden_fields.each do |input|
+        if input.is_a?(Hash)
+          key = input.keys.first
+          name = input[key]
+        else
+          key = name = input
+        end
+
+        it "should have a hidden field for '#{name}'" do
+          direct_uploader.stub(key).and_return(key.to_s)
+          form_with_file_field_and_no_redirect.should have_input(
             :direct_uploader,
             key,
             :type => :hidden,
@@ -45,7 +78,7 @@ describe CarrierWaveDirect::FormBuilder do
       end
 
       it "should have an input for a file to upload" do
-        form_with_file_field.should have_input(
+        form_with_default_file_field.should have_input(
           :direct_uploader,
           :video,
           :type => :file,

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -68,6 +68,12 @@ describe CarrierWaveDirect::Uploader do
     end
   end
 
+  describe ".use_action_status" do
+    it "should be false" do
+      subject.class.use_action_status.should be_false
+    end
+  end
+
   DirectUploader.fog_credentials.keys.each do |key|
     describe "##{key}" do
       it "should return the #{key.to_s.capitalize}" do
@@ -81,6 +87,7 @@ describe CarrierWaveDirect::Uploader do
   end
 
   it_should_have_accessor(:success_action_redirect)
+  it_should_have_accessor(:success_action_status)
 
   describe "#key=" do
     before { subject.key = sample(:key) }
@@ -451,6 +458,26 @@ describe CarrierWaveDirect::Uploader do
 
         it "'content-type' only if enabled" do
           conditions.should have_condition('Content-Type') if subject.class.will_include_content_type
+        end
+
+        context 'when use_action_status is true' do
+          before(:all) do
+            DirectUploader.use_action_status = true
+          end
+
+          after(:all) do
+            DirectUploader.use_action_status = false
+          end
+
+          it "'success_action_status'" do
+            subject.success_action_status = '200'
+            conditions.should have_condition("success_action_status" => "200")
+          end
+
+          it "does not have 'success_action_redirect'" do
+            subject.success_action_redirect = "http://example.com/some_url"
+            conditions.should_not have_condition("success_action_redirect" => "http://example.com/some_url")
+          end
         end
 
         context "'content-length-range of'" do


### PR DESCRIPTION
The motivation for this feature was to make carrierwave_direct compatible with jquery-fileupload.
I've added the `config.use_action_status` to enable the replacement of `success_action_redirect` with `success_action_status` in the form sent to s3.  The value of `config.use_action_status` also defaults to false in order preserve original carrierwave_direct behavior.

To use the feature set `config.use_action_status = true` in the carrierwave initializer, and set `your_uploader.success_action_status = "200"`or another status (s3 defaults to 204).

Then when creating the form use `f.file_field :avatar, use_action_status: true` to make sure the form matches the new policy.

Also, I'm currently using carrierwave_direct in a project thats going to hit production soon, so I would be interesting in becoming a maintainer!  I'd like to resolve some of the open issues and maybe add a few more features in the future (such as support for multiple uploaders in the same form).

Also, on a side note: I've set up carrierwave_direct to work with s3 in production and localhost for development, and I would be able to write up a how to if your interested.
