### PR TITLE
Fix test errors with rails 4

### DIFF
--- a/spec/support/form_builder_helpers.rb
+++ b/spec/support/form_builder_helpers.rb
@@ -14,7 +14,14 @@ module FormBuilderHelpers
   include ActionView::Helpers::FormHelper
   include CarrierWaveDirect::ActionViewExtensions::FormHelper
   include ActionView::Context
-  include ActionView::RecordIdentifier
+
+  # Try ActionView::RecrodIentifier for Rails 4
+  # else use ActionController::RecordIdentifier for Rails 3.2
+  begin
+    include ActionView::RecordIdentifier
+  rescue
+    include ActionController::RecordIdentifier
+  end
 
   include ::ViewHelpers
 


### PR DESCRIPTION
Fixed tests so they run with rails 3.2 & rails 4!

With Rails 4 we have to require action_controller and active_model.  Also, RecordIdentifiers are being deprecated in the controller so we have to include them from ActionView.
