### PR TITLE
Convert time format in policy to string using iso8601 in policy

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -81,7 +81,7 @@ module CarrierWaveDirect
 
       Base64.encode64(
         {
-          'expiration' => Time.now.utc + options[:expiration],
+          'expiration' => (Time.now + options[:expiration]).utc.iso8601,
           'conditions' => conditions
         }.to_json
       ).gsub("\n","")


### PR DESCRIPTION
- Modified the format of expiration time used in creating the policy. 

Some applications like ours have our own implementation of Time.now.to_json. This results in an invalid policy, when Time.now is directly converted to json. 

- Modified it to first convert to string using iso8601 format, before converting it to json. 