### PR TITLE
handling remote url contains escape characters

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -43,7 +43,7 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if present?
-        self.key = URI.parse(URI.encode(url)).path[1 .. -1] # explicitly set key
+        self.key = URI.parse(URI.encode(url, " []+()")).path[1 .. -1] # explicitly set key
       else
         @key = "#{store_dir}/#{guid}/#{FILENAME_WILDCARD}"
       end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -347,6 +347,18 @@ describe CarrierWaveDirect::Uploader do
         end
       end
 
+      context "and the model's remote url contains escape characters" do
+        before do 
+            subject.key = nil
+            subject.stub(:present?).and_return(:true)
+            subject.stub(:url).and_return("http://anyurl.com/any_path/video_dir/filename ()+[]2.avi")
+        end
+
+        it "should be escaped and replaced with non whitespace characters" do
+            subject.key.should =~ /filename%20%28%29%2B%5B%5D2.avi$/
+        end
+      end
+
       context "and the model's remote #{sample(:mounted_as)} url is blank" do
         before do
           mounted_model.stub(


### PR DESCRIPTION
1. Handling remote url that contains escape characters (especially "[]")
