### PR TITLE
stack level too deep when mount on a column named "file"

### DIFF
--- a/lib/carrierwave_direct/mount.rb
+++ b/lib/carrierwave_direct/mount.rb
@@ -9,9 +9,11 @@ module CarrierWaveDirect
       # Don't go further unless the class included CarrierWaveDirect::Uploader
       return unless uploader.ancestors.include?(CarrierWaveDirect::Uploader)
 
-      uploader.class_eval <<-RUBY, __FILE__, __LINE__+1
-        def #{column}; self; end
-      RUBY
+      unless uploader.instance_methods.include?(column)
+        uploader.class_eval <<-RUBY, __FILE__, __LINE__+1
+          def #{column}; self; end
+        RUBY
+      end
 
       self.instance_eval <<-RUBY, __FILE__, __LINE__+1
         attr_accessor :remote_#{column}_net_url


### PR DESCRIPTION
If you have you uploader mounted on a column named ```file```, like this:

```ruby
class Attachment < ActiveRecord::Base
  attr_accessible :name, :file, :size, :attachable_id, :attachable_type, :content_type
  mount_uploader :file, AttachmentUploader
  ... 
end
```

You will see a ```SystemStackError (stack level too deep)``` when trying to use ```create```, like this:

```
Attachment.new(params[:attachment])
```

It's the same problem related in #10 and #18. I don't know why they closed the other issues, when it's clearly a problem in the gem(in my opinion), since it works with regular carrierwave(and it's pretty hard for a user to figure it out).