### PR TITLE
Only render 1 hidden input field for success_action_redirect

### DIFF
--- a/lib/carrierwave_direct/form_builder.rb
+++ b/lib/carrierwave_direct/form_builder.rb
@@ -8,8 +8,6 @@ module CarrierWaveDirect
 
       if options[:use_action_status]
         fields << hidden_field(:success_action_status, :name => "success_action_status")
-      else
-        fields << hidden_field(:success_action_redirect, :name => "success_action_redirect")
       end
 
       fields << super


### PR DESCRIPTION
Currently there are 2 hidden input fields for the same success_action_redirect
