### PR TITLE
Strip C:\fakepath from upload path

### DIFF
--- a/lib/carrierwave_direct/test/capybara_helpers.rb
+++ b/lib/carrierwave_direct/test/capybara_helpers.rb
@@ -15,7 +15,11 @@ module CarrierWaveDirect
       end
 
       def find_upload_path
-        page.find("input[@name='file']").value
+        # Standards compliant browsers report C:\fakepath as part of
+        # their value. We should strip this for our test helpers as
+        # it is not submitted to the upload
+        # http://davidwalsh.name/fakepath
+        page.find("input[@name='file']").value.sub("C:\\fakepath\\", "")
       end
 
       def upload_directly(uploader, button_locator, options = {})

--- a/spec/test/capybara_helpers_spec.rb
+++ b/spec/test/capybara_helpers_spec.rb
@@ -148,10 +148,15 @@ describe CarrierWaveDirect::Test::CapybaraHelpers do
   describe "#find_upload_path" do
     before do
       stub_page
-      find_element_value("input[@name='file']", "upload path")
     end
 
     it "should try to find the upload path on the page" do
+      find_element_value("input[@name='file']", "upload path")
+      expect(subject.find_upload_path).to eq "upload path"
+    end
+
+    it "strips fakepath for standards compliant browsers" do
+      find_element_value("input[@name='file']", "C:\\fakepath\\upload path")
       expect(subject.find_upload_path).to eq "upload path"
     end
   end


### PR DESCRIPTION
Standards compliant browsers report C:\fakepath as part of
their value. We should strip this for our test helpers as
it is not submitted to the upload

http://davidwalsh.name/fakepath
