### PR TITLE
Fix malformed keys when using fog with endpoint

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -79,7 +79,14 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if present?
-        self.key = URI.parse(URI.encode(url, " []+()")).path[1 .. -1] # explicitly set key
+        path = URI.parse(URI.encode(url, " []+()")).path
+
+        # explicitly set key
+        self.key = if self.fog_credentials.has_key?(:endpoint)
+          path.gsub(/\A\/.*?\//, "") # strip bucket name from path
+        else
+          path[1 .. -1] 
+        end
       else
         @key = "#{store_dir}/#{guid}/#{FILENAME_WILDCARD}"
       end

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -79,7 +79,7 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if present?
-        path = URI.parse(URI.decode(url)).path
+        path = URI.decode(URI.parse(url).path)
 
         # explicitly set key
         self.key = if self.fog_credentials.has_key?(:endpoint)

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -79,7 +79,7 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if present?
-        path = URI.parse(URI.encode(url, " []+()")).path
+        path = URI.parse(URI.decode(url)).path
 
         # explicitly set key
         self.key = if self.fog_credentials.has_key?(:endpoint)


### PR DESCRIPTION
If fog config options include an endpoint, keys generated for previously created uploads end up having bucket name duplicated in the URL. This results in not found errors after successful uploads.
