### PR TITLE
Cache policy attribute of uploader

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -37,6 +37,10 @@ module CarrierWaveDirect
       @policy ||= generate_policy(options)
     end
 
+    def clear_policy!
+      @policy = nil
+    end
+
     def signature
       Base64.encode64(
         OpenSSL::HMAC.digest(

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -446,6 +446,20 @@ describe CarrierWaveDirect::Uploader do
     end
   end
 
+  describe "clear_policy!" do
+    it "should reset the cached policy string" do
+      Timecop.freeze(Time.now) do
+        @policy_now = subject.policy
+      end
+      subject.clear_policy!
+
+      Timecop.freeze(1.second.from_now) do
+        @policy_after_reset = subject.policy
+      end
+      expect(@policy_after_reset).not_to eql @policy_now
+    end
+  end
+
   describe "#signature" do
     it "should not contain any new lines" do
       expect(subject.signature).to_not include("\n")


### PR DESCRIPTION
Without such caching, calling `signature` computes a new policy, which may be different to a previous or subsequent retrieval of the policy, so the signature may not match what is expected.

This addresses #127 which I opened earlier.

I don't see any particular downside to this caching, since these attributes are only used to build the form. However, if you have any objections I'd be happy to revise the approach I've taken here.
