### PR TITLE
Bugfix: Use the 'mounted on' column for checking uniqueness.

### DIFF
--- a/lib/carrierwave_direct/validations/active_model.rb
+++ b/lib/carrierwave_direct/validations/active_model.rb
@@ -12,7 +12,8 @@ module CarrierWaveDirect
       class UniqueFilenameValidator < ::ActiveModel::EachValidator
         def validate_each(record, attribute, value)
           if record.new_record? && record.errors[attribute].empty? && (record.send("has_#{attribute}_upload?") || record.send("has_remote_#{attribute}_net_url?"))
-            if record.class.where(attribute => record.send(attribute).filename).exists?
+            column = record.class.uploader_options[attribute].fetch(:mount_on, attribute)
+            if record.class.where(column => record.send(attribute).filename).exists?
               record.errors.add(attribute, :carrierwave_direct_filename_taken)
             end
           end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -15,15 +15,23 @@ describe CarrierWaveDirect::ActiveRecord do
       create_table :parties, :force => true do |t|
         t.column :video, :string
       end
+
+      create_table :dances, :force => true do |t|
+        t.column :location, :string
+      end
     end
 
     def self.down
       drop_table :parties
+      drop_table :dances
     end
   end
 
   class Party < ActiveRecord::Base
     mount_uploader :video, DirectUploader
+  end
+
+  class Dance < ActiveRecord::Base
   end
 
   ActiveRecord::Base.establish_connection(dbconfig)
@@ -148,6 +156,17 @@ describe CarrierWaveDirect::ActiveRecord do
       it "should be turned on by default" do
         party_class.should_receive(:validates_filename_uniqueness_of).with(:video)
         mount_uploader
+      end
+
+      context "mount_on: option is used" do
+        let(:dance) { Dance.new }
+
+        before { Dance.mount_uploader(:non_existing_column, DirectUploader, mount_on: :location)    }
+        before { dance.non_existing_column.key = sample_key}
+
+        it "uses the column it's mounted on for checking uniqueness" do
+          expect { dance.valid? }.to_not raise_error
+        end
       end
 
       context "another Party with a duplicate video filename" do


### PR DESCRIPTION
When using an uploader name which does not map onto an existing column and using the `:mount_on` option for mapping to an existing one the uniqueness validator fails with an error because he's using the uploader's name for AR's `where`.

I created a new `Dance` class for this bugfix because re-using `Party` and mounting another uploader intefered too much with a lot of other test cases.
