### PR TITLE
allow form_builder to configure use_action_status

### DIFF
--- a/lib/carrierwave_direct/form_builder.rb
+++ b/lib/carrierwave_direct/form_builder.rb
@@ -5,7 +5,7 @@ module CarrierWaveDirect
     def file_field(method, options = {})
       options.merge!(:name => "file")
 
-      fields = required_base_fields
+      fields = required_base_fields(options)
 
       fields << content_type_field(options)
 
@@ -27,12 +27,12 @@ module CarrierWaveDirect
 
     private
 
-    def required_base_fields
+    def required_base_fields(options)
       hidden_field(:key,                     :name => "key") <<
       hidden_field(:aws_access_key_id,       :name => "AWSAccessKeyId") <<
       hidden_field(:acl,                     :name => "acl") <<
-      hidden_field(:policy,                  :name => "policy") <<
-      hidden_field(:signature,               :name => "signature")
+      hidden_field(:policy,                  :name => "policy",    :value => @object.policy(options)) <<
+      hidden_field(:signature,               :name => "signature", :value => @object.signature(options))
     end
 
     def content_type_field(options)
@@ -42,7 +42,7 @@ module CarrierWaveDirect
     end
 
     def success_action_field(options)
-      if @object.use_action_status
+      if options.fetch(:use_action_status, @object.use_action_status)
         hidden_field(:success_action_status, :name => "success_action_status")
       else
         hidden_field(:success_action_redirect, :name => "success_action_redirect")

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -43,7 +43,7 @@ module CarrierWaveDirect
       conditions << {"bucket" => fog_directory}
       conditions << {"acl" => acl}
 
-      if use_action_status
+      if options.fetch(:use_action_status, use_action_status)
         conditions << {"success_action_status" => success_action_status}
       else
         conditions << {"success_action_redirect" => success_action_redirect}
@@ -59,11 +59,11 @@ module CarrierWaveDirect
       ).gsub("\n","")
     end
 
-    def signature
+    def signature(options = {})
       Base64.encode64(
         OpenSSL::HMAC.digest(
           OpenSSL::Digest.new('sha1'),
-          aws_secret_access_key, policy
+          aws_secret_access_key, policy(options)
         )
       ).gsub("\n","")
     end
@@ -105,7 +105,7 @@ module CarrierWaveDirect
 
     def extension_regexp
       allowed_file_types = extension_white_list
-      extension_regexp = allowed_file_types.present? && allowed_file_types.any? ?  "(#{allowed_file_types.join("|")})" : "\\w+"
+      allowed_file_types.present? && allowed_file_types.any? ?  "(#{allowed_file_types.join("|")})" : "\\w+"
     end
 
     def filename

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -253,7 +253,7 @@ describe CarrierWaveDirect::Uploader do
       end
 
       context "and the model's remote url contains escape characters" do
-        before do 
+        before do
             subject.key = nil
             allow(subject).to receive(:present?).and_return(:true)
             allow(subject).to receive(:url).and_return("http://anyurl.com/any_path/video_dir/filename ()+[]2.avi")
@@ -373,6 +373,13 @@ describe CarrierWaveDirect::Uploader do
           expect(conditions).to have_condition("success_action_redirect" => "http://example.com/some_url")
         end
 
+        it "'success_action_status'" do
+          subject.success_action_status = '200'
+          expect(conditions(
+            :use_action_status => true
+          )).to have_condition('success_action_status' => '200')
+        end
+
         it "does not have 'content-type' when will_include_content_type is false" do
           allow(subject.class).to receive(:will_include_content_type).and_return(false)
           expect(conditions).to_not have_condition('Content-Type')
@@ -400,6 +407,13 @@ describe CarrierWaveDirect::Uploader do
           it "does not have 'success_action_redirect'" do
             subject.success_action_redirect = "http://example.com/some_url"
             expect(conditions).to_not have_condition("success_action_redirect" => "http://example.com/some_url")
+          end
+
+          it 'can be overridden by options' do
+            subject.success_action_redirect = 'http://example.com/some_url'
+            expect(conditions(
+              :use_action_status => false
+            )).to have_condition('success_action_redirect' => 'http://example.com/some_url')
           end
         end
 
@@ -445,6 +459,14 @@ describe CarrierWaveDirect::Uploader do
       expect(Base64.decode64(subject.signature)).to eq OpenSSL::HMAC.digest(
         OpenSSL::Digest.new('sha1'),
         subject.aws_secret_access_key, subject.policy
+      )
+    end
+
+    it 'can accept an options hash for computing the policy' do
+      opts = { :use_action_status => true }
+      expect(Base64.decode64(subject.signature(opts))).to eq OpenSSL::HMAC.digest(
+        OpenSSL::Digest.new('sha1'),
+        subject.aws_secret_access_key, subject.policy(opts)
       )
     end
   end


### PR DESCRIPTION
For modern browsers, I would like to use the `success_action_status` option for direct upload to Amazon S3 but for IE versions that do not support AJAX with CORS, I need to fall back to `success_action_redirect`.

This pull request allows the form builder to be configured at render time instead of looking at the static `use_action_status` option.
