### PR TITLE
The asset host should not be used for direct_url uploads.

### DIFF
--- a/lib/carrierwave_direct/uploader/direct_url.rb
+++ b/lib/carrierwave_direct/uploader/direct_url.rb
@@ -13,6 +13,11 @@ module CarrierWaveDirect
         fog_uri
       end
 
+      def asset_host
+        # overridden to prevent file uploads to the configured
+        # asset host (if any).
+      end
+
     end
   end
 end

--- a/spec/uploader/direct_url_spec.rb
+++ b/spec/uploader/direct_url_spec.rb
@@ -50,7 +50,16 @@ describe CarrierWaveDirect::Uploader::DirectUrl do
       end
     end
   end
+
+  describe "#asset_host" do
+    it "should return nil" do
+      subject.class.configure do |config|
+        config.asset_host = "http://foo.bar"
+      end
+
+      expect(subject.asset_host).to be_nil
+    end
+  end
+
 end
-
-
 


### PR DESCRIPTION
Configuring an asset host (CDN) on Carrierwave should not change where file uploads are sent. Uploads should always be sent to the third party (origin) site configured within the fog credentials.

Any feedback is certainly welcome.
