### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Note if `User` is not an ActiveRecord object e.g.
 
 ```ruby
 class User
+  extend CarrierWave::Mount
+  extend CarrierWaveDirect::Mount
+
   mount_uploader :avatar, AvatarUploader
 end
 ```


### PR DESCRIPTION
I tried mounting an uploader on a plain old ruby class and got some errors.

I added the following:

```
extend CarrierWave::Mount
extend CarrierWaveDirect::Mount
```

and it works like a charm.

So here's the updated README.md so future generations don't have to go digging around.
