### PR TITLE
Let Carrierwave generate urls. Fixes #123 #151

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -61,7 +61,7 @@ module CarrierWaveDirect
     def key
       return @key if @key.present?
       if present?
-        self.key = URI.parse(encoded_url).path[1 .. -1] # explicitly set key
+        self.key = decoded_key # explicitly set key
       else
         @key = "#{store_dir}/#{guid}/#{FILENAME_WILDCARD}"
       end
@@ -107,8 +107,8 @@ module CarrierWaveDirect
 
     private
 
-    def encoded_url
-      URI.encode(URI.decode(url), " []+()")
+    def decoded_key
+      URI.decode(URI.parse(url).path[1 .. -1])
     end
 
     def key_from_file(fname)

--- a/lib/carrierwave_direct/uploader/direct_url.rb
+++ b/lib/carrierwave_direct/uploader/direct_url.rb
@@ -3,14 +3,11 @@ module CarrierWaveDirect
     module DirectUrl
 
       def direct_fog_url(options = {})
-        fog_uri = CarrierWave::Storage::Fog::File.new(self, CarrierWave::Storage::Fog.new(self), nil).public_url
         if options[:with_path]
-          uri = URI.parse(fog_uri.chomp('/'))
-          path = "/#{URI.decode(key)}"
-          uri.path += URI.escape(path)
-          fog_uri = uri.to_s
+          url
+        else
+          CarrierWave::Storage::Fog::File.new(self, CarrierWave::Storage::Fog.new(self), nil).public_url
         end
-        fog_uri
       end
 
     end

--- a/spec/uploader/direct_url_spec.rb
+++ b/spec/uploader/direct_url_spec.rb
@@ -15,38 +15,9 @@ describe CarrierWaveDirect::Uploader::DirectUrl do
     end
 
     context ":with_path => true" do
-
-      context "#key is set to '#{sample(:path_with_special_chars)}'" do
-        before { subject.key = sample(:path_with_special_chars) }
-
-        it "should return the full url with '/#{URI.escape(sample(:path_with_special_chars))}' as the path" do
-          direct_fog_url = CarrierWave::Storage::Fog::File.new(
-            subject, nil, nil
-          ).public_url
-          expect(subject.direct_fog_url(:with_path => true)).to eq direct_fog_url + "#{URI.escape(sample(:path_with_special_chars))}"
-        end
-      end
-
-      context "#key is set to '#{sample(:path_with_escaped_chars)}'" do
-        before { subject.key = sample(:path_with_escaped_chars) }
-
-        it "should return the full url with '/#{sample(:path_with_escaped_chars)}' as the path" do
-          direct_fog_url = CarrierWave::Storage::Fog::File.new(
-            subject, nil, nil
-          ).public_url
-          expect(subject.direct_fog_url(:with_path => true)).to eq direct_fog_url + sample(:path_with_escaped_chars)
-        end
-      end
-
-      context "#key is set to '#{sample(:path)}'" do
-        before { subject.key = sample(:path) }
-
-        it "should return the full url with '/#{sample(:path)}' as the path" do
-          direct_fog_url = CarrierWave::Storage::Fog::File.new(
-            subject, nil, nil
-          ).public_url
-          expect(subject.direct_fog_url(:with_path => true)).to eq direct_fog_url + "#{sample(:path)}"
-        end
+      it "should return the full url set by carrierwave" do
+        allow(subject).to receive(:url).and_return("url")
+        expect(subject.direct_fog_url(:with_path => true)).to eq "url"
       end
     end
   end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -240,28 +240,16 @@ describe CarrierWaveDirect::Uploader do
         end
       end
 
-      context "and the model's remote #{sample(:mounted_as)} url has whitespace in it" do
+      context "and the model's remote #{sample(:mounted_as)} url has special characters in it" do
         before do
           allow(mounted_model).to receive(
             "remote_#{mounted_subject.mounted_as}_url"
-          ).and_return("http://anyurl.com/any_path/video_dir/filename 2.avi")
+          ).and_return("http://anyurl.com/any_path/video_dir/filename ()+[]2.avi")
         end
 
-        it "should be sanitized (whitespace replaced with _)" do
+        it "should be sanitized (special characters replaced with _)" do
           mounted_subject.filename
-          expect(mounted_subject.key).to match /filename_2.avi$/
-        end
-      end
-
-      context "and the model's remote url contains escape characters" do
-        before do
-          subject.key = nil
-          allow(subject).to receive(:present?).and_return(:true)
-          allow(subject).to receive(:url).and_return("http://anyurl.com/any_path/video_dir/filename ()+[]2.avi")
-        end
-
-        it "should be escaped and replaced with non whitespace characters" do
-          expect(subject.key).to match /filename%20%28%29%2B%5B%5D2.avi/
+          expect(mounted_subject.key).to match /filename___\+__2.avi$/
         end
       end
 
@@ -273,7 +261,7 @@ describe CarrierWaveDirect::Uploader do
         end
 
         it "should not double escape already escaped characters" do
-          expect(subject.key).to match /filename%20%28%29%2B%5B%5D2.avi/
+          expect(subject.key).to match /filename \(\)\+\[\]2.avi/
         end
 
       end


### PR DESCRIPTION
The url generation by CarrierwaveDirect is complex and has issues (#129, #151).
Carrierwave already generates urls for us.
By letting Carrierwave generate the urls we can remove code from CarrierwaveDirect.
Another benefit is default support for private storage on S3 (#123).

I have this branch currently working smoothly on production with private S3 storage.
DirectUrl::direct_fog_url(with_path: true) should probably be deprecated as it just calls url.