### PR TITLE
Escape all remaining reserved chars in direct_fog_url

### DIFF
--- a/lib/carrierwave_direct/uploader/direct_url.rb
+++ b/lib/carrierwave_direct/uploader/direct_url.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module CarrierWaveDirect
   module Uploader
     module DirectUrl
@@ -7,7 +9,7 @@ module CarrierWaveDirect
         if options[:with_path]
           uri = URI.parse(fog_uri.chomp('/'))
           path = "/#{URI.decode(key)}"
-          uri.path += URI.escape(path, '?:[]')
+          uri.path += CGI.escape(path)
           fog_uri = uri.to_s
         end
         fog_uri

--- a/lib/carrierwave_direct/uploader/direct_url.rb
+++ b/lib/carrierwave_direct/uploader/direct_url.rb
@@ -7,7 +7,7 @@ module CarrierWaveDirect
         if options[:with_path]
           uri = URI.parse(fog_uri.chomp('/'))
           path = "/#{URI.decode(key)}"
-          uri.path += URI.escape(path)
+          uri.path += URI.escape(path, '?:[]')
           fog_uri = uri.to_s
         end
         fog_uri


### PR DESCRIPTION
This fixes using direct_fog_url with files that have these `?:[]` in the filename.
From URI::Parser
URI regexp pattern for rel_segment
      RESERVED = ";/?:@&=+$,\\[\\]"
      rel_segment   = ( unreserved | escaped |
                          ";" | "@" | "&" | "=" | "+" |
                          "$" | "," )
Hence, '?:[]' need to be escaped for the URI path to not throw exceptions on parsing.