### PR TITLE
Implement the carrierwave default_url method in uploader.

### DIFF
--- a/lib/carrierwave_direct.rb
+++ b/lib/carrierwave_direct.rb
@@ -8,8 +8,10 @@ module CarrierWaveDirect
 
   module Uploader
     require "carrierwave_direct/uploader/configuration"
+    require "carrierwave_direct/uploader/default_url"
 
     CarrierWave::Uploader::Base.send(:include, Configuration)
+    CarrierWave::Uploader::Base.send(:include, DefaultUrl)
   end
 
   module Test

--- a/lib/carrierwave_direct/uploader/default_url.rb
+++ b/lib/carrierwave_direct/uploader/default_url.rb
@@ -1,0 +1,15 @@
+module CarrierWaveDirect
+  module Uploader
+    module DefaultUrl
+
+      def default_url(*args)
+        return unless respond_to?(:has_key?) && has_key?
+
+        fog = CarrierWave::Storage::Fog.new(self)
+        CarrierWave::Storage::Fog::File.new(self, fog, key).url
+      end
+
+    end
+  end
+end
+

--- a/spec/uploader/default_url_spec.rb
+++ b/spec/uploader/default_url_spec.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+#
+require 'spec_helper'
+require 'data/sample_data'
+
+describe CarrierWaveDirect::Uploader::DirectUrl do
+
+  let(:subject) { DirectUploader.new }
+
+  describe "#default_url" do
+    context "#key is not set" do
+      it "should return nil" do
+        expect(subject.default_url).to eq nil
+      end
+    end
+
+    context "#key is not a defined method" do
+      before { subject.stub(:respond_to?).with(:has_key?).and_return(false) }
+
+      it "should return nil" do
+        expect(subject.default_url).to eq nil
+      end
+    end
+
+    context "#key is set to '#{sample(:path)}'" do
+      before { subject.key = sample(:path) }
+
+      it "should return the result from CarrierWave::Storage::Fog::File#url" do
+        expect(
+          subject.default_url
+        ).to eq CarrierWave::Storage::Fog::File.new( subject, nil, sample(:path)).url
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
This change provides a means for accessing the fog file url prior to model persistence.

We came across an issue where we'd uploaded the file and then attempted to save the key. In situations where the key is _not_ saved due to validation errors, there was no way (that I could find) to generate the full path to the uploaded file.  This PR addresses that by using carrierwave's `default_url` hook.

Certainly open to any/all feedback.
