### PR TITLE
Adding prefix to key attribute. Fixes #148

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ end
 After uploading to S3, You'll need to update the uploader object with the returned key in the controller action that corresponds to `new_user_url`:
 
 ```ruby
-@uploader.update_attribute :key, params[:key]
+@uploader.update_attribute :avatar_key, params[:key]
 ```
 
 You can also pass html options like this:

--- a/lib/carrierwave_direct/mount.rb
+++ b/lib/carrierwave_direct/mount.rb
@@ -23,11 +23,11 @@ module CarrierWaveDirect
       include mod
       mod.class_eval <<-RUBY, __FILE__, __LINE__+1
 
-        def key
+        def #{column}_key
           send(:#{column}).key
         end
 
-        def key=(k)
+        def #{column}_key=(k)
           send(:#{column}).key = k
         end
 

--- a/lib/carrierwave_direct/mount.rb
+++ b/lib/carrierwave_direct/mount.rb
@@ -23,6 +23,14 @@ module CarrierWaveDirect
       include mod
       mod.class_eval <<-RUBY, __FILE__, __LINE__+1
 
+        def key
+          warn "key method is deprecated, please use column_key method instead."
+        end
+
+        def key=(k)
+          warn "key= method is deprecated, please use column_key= method instead."
+        end
+
         def #{column}_key
           send(:#{column}).key
         end

--- a/lib/carrierwave_direct/orm/activerecord.rb
+++ b/lib/carrierwave_direct/orm/activerecord.rb
@@ -32,7 +32,7 @@ module CarrierWaveDirect
       self.instance_eval <<-RUBY, __FILE__, __LINE__+1
         attr_accessor   :skip_is_attached_validations
         unless defined?(ActiveModel::ForbiddenAttributesProtection) && ancestors.include?(ActiveModel::ForbiddenAttributesProtection)
-          attr_accessible :key, :remote_#{column}_net_url
+          attr_accessible :#{column}_key, :remote_#{column}_net_url
         end
       RUBY
 

--- a/lib/carrierwave_direct/validations/active_model.rb
+++ b/lib/carrierwave_direct/validations/active_model.rb
@@ -22,7 +22,7 @@ module CarrierWaveDirect
 
       class FilenameFormatValidator < ::ActiveModel::EachValidator
         def validate_each(record, attribute, value)
-          if record.send("has_#{attribute}_upload?") && record.key !~ record.send(attribute).key_regexp
+          if record.send("has_#{attribute}_upload?") && record.send("#{attribute}_key") !~ record.send(attribute).key_regexp
             extensions = record.send(attribute).extension_white_list
             message = I18n.t("errors.messages.carrierwave_direct_filename_invalid")
 

--- a/spec/mount_spec.rb
+++ b/spec/mount_spec.rb
@@ -40,7 +40,7 @@ describe CarrierWaveDirect::Mount do
       end
     end
 
-    it_should_delegate(:key, :to => "video#key", :accessible => { "has_video_upload?" => false })
+    it_should_delegate(:video_key, :to => "video#key", :accessible => { "has_video_upload?" => false })
   end
 end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -118,7 +118,7 @@ describe CarrierWaveDirect::ActiveRecord do
     shared_examples_for "without an upload" do
       before do
         subject.remote_video_net_url = remote_video_net_url
-        subject.key = upload_path
+        subject.video_key = upload_path
       end
 
       it "should not be valid on create" do
@@ -169,7 +169,7 @@ describe CarrierWaveDirect::ActiveRecord do
         let(:dance) { Dance.new }
 
         before { Dance.mount_uploader(:non_existing_column, DirectUploader, mount_on: :location)    }
-        before { dance.non_existing_column.key = sample_key}
+        before { dance.non_existing_column_key = sample_key}
 
         it "uses the column it's mounted on for checking uniqueness" do
           expect { dance.valid? }.to_not raise_error
@@ -219,7 +219,7 @@ describe CarrierWaveDirect::ActiveRecord do
       context "where the file upload is" do
         context "nil" do
           before do
-            subject.key = nil
+            subject.video_key = nil
           end
 
           it "should be valid" do
@@ -229,7 +229,7 @@ describe CarrierWaveDirect::ActiveRecord do
 
         context "blank" do
           before do
-            subject.key = ""
+            subject.video_key = ""
           end
 
           it "should be valid" do
@@ -245,7 +245,7 @@ describe CarrierWaveDirect::ActiveRecord do
 
         context "and the uploaded file's extension is included in the list" do
           before do
-            subject.key = sample_key(:extension => "avi")
+            subject.video_key = sample_key(:extension => "avi")
           end
 
           it "should be valid" do
@@ -255,7 +255,7 @@ describe CarrierWaveDirect::ActiveRecord do
 
         context "but uploaded file's extension is not included in the list" do
           before do
-            subject.key = sample_key(:extension => "mp3")
+            subject.video_key = sample_key(:extension => "mp3")
           end
 
           it_should_behave_like "an invalid filename"
@@ -475,7 +475,7 @@ describe CarrierWaveDirect::ActiveRecord do
 
         context "with an upload by file" do
           before do
-            subject.key = sample_key
+            subject.video_key = sample_key
           end
 
           it "should be valid" do
@@ -527,7 +527,7 @@ describe CarrierWaveDirect::ActiveRecord do
 
     describe "#key" do
       it "should be accessible" do
-        party_class.new(:key => "some key").key.should == "some key"
+        party_class.new(:video_key => "some key").video_key.should == "some key"
       end
     end
 
@@ -561,7 +561,7 @@ describe CarrierWaveDirect::ActiveRecord do
       context "has an upload" do
         context "with a valid filename" do
           before do
-            subject.key = sample_key(:model_class => subject.class)
+            subject.video_key = sample_key(:model_class => subject.class)
           end
 
           it "should be true" do
@@ -572,7 +572,7 @@ describe CarrierWaveDirect::ActiveRecord do
         end
 
         context "with an invalid filename" do
-          before { subject.key = sample_key(:model_class => subject.class, :valid => false) }
+          before { subject.video_key = sample_key(:model_class => subject.class, :valid => false) }
 
           it "should be false" do
             subject.filename_valid?.should be false

--- a/spec/uploader/direct_url_spec.rb
+++ b/spec/uploader/direct_url_spec.rb
@@ -7,6 +7,8 @@ describe CarrierWaveDirect::Uploader::DirectUrl do
 
   let(:subject) { DirectUploader.new }
 
+  let(:mounted_subject) { DirectUploader.new(mounted_model, sample(:mounted_as)) }
+
   describe "#direct_fog_url" do
     it "should return the result from CarrierWave::Storage::Fog::File#public_url" do
       expect(subject.direct_fog_url).to eq CarrierWave::Storage::Fog::File.new(
@@ -22,6 +24,3 @@ describe CarrierWaveDirect::Uploader::DirectUrl do
     end
   end
 end
-
-
-


### PR DESCRIPTION
 The prefix is the mounted column name, so that users can upload multiple keys/files using the same model.