### PR TITLE
Got rid of uuidtools dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ Bug Fixes:
   * Allow uploader columns to be named `file` (Diego Plentz @plentz and Moisés Viloria @mois3x)
   * `["starts-with", "$utf8", ""]` is not needed as condition (Rocco Galluzzo @byterussian)
 
+Misc:
+  * Dropped support for ruby 1.9, it has [reached its end of life](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/) 
+  * Add 2.2.0 support to travis. 
+
 ### 0.0.15
 
 [Full Changes](https://github.com/dwilkie/carrierwave_direct/compare/v0.0.14...v0.0.15)

--- a/carrierwave_direct.gemspec
+++ b/carrierwave_direct.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "carrierwave_direct"
 
   s.add_dependency "carrierwave"
-  s.add_dependency "uuidtools"
   s.add_dependency "fog"
 
   s.add_development_dependency "rspec"

--- a/carrierwave_direct.gemspec
+++ b/carrierwave_direct.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/dwilkie/carrierwave_direct"
   s.summary     = %q{Upload direct to S3 using CarrierWave}
   s.description = %q{Process your uploads in the background by uploading directly to S3}
-  s.required_ruby_version = ">= 1.9.0"
+  s.required_ruby_version = ">= 2.0.0"
 
   s.rubyforge_project = "carrierwave_direct"
 

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "carrierwave"
-gem "uuidtools"
 gem "fog"
 
 group :test do

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "carrierwave"
-gem "uuidtools"
 gem "fog"
 
 group :test do

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "carrierwave"
-gem "uuidtools"
 gem "fog"
 
 group :test do

--- a/lib/carrierwave_direct.rb
+++ b/lib/carrierwave_direct.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require "carrierwave"
-require "uuidtools"
 require "fog"
 
 module CarrierWaveDirect

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require "securerandom"
 require "carrierwave_direct/uploader/content_type"
 require "carrierwave_direct/uploader/direct_url"
 
@@ -74,7 +75,7 @@ module CarrierWaveDirect
     end
 
     def guid
-      UUIDTools::UUID.random_create
+      SecureRandom.uuid
     end
 
     def has_key?


### PR DESCRIPTION
Since you're targeting ruby >= 1.9 there's no need to include an additional dependency.

Use SecureRandom.uuid instead.