### PR TITLE
Convert expiration time in policy to an ISO8601 string

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -151,7 +151,7 @@ module CarrierWaveDirect
 
       Base64.encode64(
         {
-          'expiration' => Time.now.utc + options[:expiration],
+          'expiration' => (Time.now + options[:expiration]).utc.iso8601,
           'conditions' => conditions
         }.to_json
       ).gsub("\n","")


### PR DESCRIPTION
Relying on the default `Time#to_json` may or may not result in a date which is
ISO8601 format, which is required by Amazon.

Using Active Support appears to do the right thing. However using the default JSON gem results in:
```xml
<Error>
<Code>InvalidPolicyDocument</Code>
<Message>
Invalid Policy: Invalid 'expiration' value: '2015-10-17 03:15:59 UTC'
</Message>
</Error>
```

Similarly if using a custom JSON conversion this could cause problems. So add an explicit
ISO8601 conversion.

This is the same problem and fix proposed by @asmatameem in pull request https://github.com/dwilkie/carrierwave_direct/pull/96 this time with a test.