### PR TITLE
Update policies & signature sto use Aws sig v4 (AWS4-HMAC-SHA256)

### DIFF
--- a/lib/carrierwave_direct/form_builder.rb
+++ b/lib/carrierwave_direct/form_builder.rb
@@ -29,10 +29,12 @@ module CarrierWaveDirect
 
     def required_base_fields
       hidden_field(:key,                     :name => "key") <<
-      hidden_field(:aws_access_key_id,       :name => "AWSAccessKeyId") <<
       hidden_field(:acl,                     :name => "acl") <<
       hidden_field(:policy,                  :name => "policy") <<
-      hidden_field(:signature,               :name => "signature")
+      hidden_field(:signature,               :name => "X-Amz-Signature") <<
+      hidden_field(:credential,              :name => "X-Amz-Credential") <<
+      hidden_field(:algorithm,               :name => "X-Amz-Algorithm") <<
+      hidden_field(:date,                    :name => "X-Amz-Date")
     end
 
     def content_type_field(options)

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -24,7 +24,12 @@ module CarrierWaveDirect
 
     include CarrierWaveDirect::Uploader::ContentType
     include CarrierWaveDirect::Uploader::DirectUrl
-
+    
+    #ensure that region returns something. Since sig v4 it is required in the signing key & credentials
+    def region
+      defined?(super) ? super : "us-east-1"
+    end
+    
     def acl
       fog_public ? 'public-read' : 'private'
     end

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -12,11 +12,13 @@ end
 shared_examples_for 'hidden values form' do
   hidden_fields = [
                     :key,
-                    {:aws_access_key_id => "AWSAccessKeyId"},
+                    {:credential => "X-Amz-Credential"},
+                    {:algorithm => "X-Amz-Algorithm"},
+                    {:date => "X-Amz-Date"},
+                    {:signature => "X-Amz-Signature"},
                     :acl,
                     :success_action_redirect,
-                    :policy,
-                    :signature
+                    :policy
                   ]
 
   hidden_fields.each do |input|
@@ -60,19 +62,23 @@ describe CarrierWaveDirect::FormBuilder do
 
     default_hidden_fields = [
                       :key,
-                      {:aws_access_key_id => "AWSAccessKeyId"},
+                      {:credential => "X-Amz-Credential"},
+                      {:algorithm => "X-Amz-Algorithm"},
+                      {:date => "X-Amz-Date"},
+                      {:signature => "X-Amz-Signature"},
                       :acl,
                       :success_action_redirect,
                       :policy,
-                      :signature
                     ]
     status_hidden_fields = [
                       :key,
-                      {:aws_access_key_id => "AWSAccessKeyId"},
+                      {:credential => "X-Amz-Credential"},
+                      {:algorithm => "X-Amz-Algorithm"},
+                      {:date => "X-Amz-Date"},
+                      {:signature => "X-Amz-Signature"},
                       :acl,
                       :success_action_status,
                       :policy,
-                      :signature
                     ]
 
     # http://aws.amazon.com/articles/1434?_encoding=UTF8

--- a/spec/support/carrier_wave_config.rb
+++ b/spec/support/carrier_wave_config.rb
@@ -4,8 +4,7 @@ CarrierWave.configure do |config|
   config.fog_credentials = {
     :provider               => 'AWS',
     :aws_access_key_id      => 'AWS_ACCESS_KEY_ID',
-    :aws_secret_access_key  => 'AWS_SECRET_ACCESS_KEY',
-    :region                 => 'eu-east-1'
+    :aws_secret_access_key  => 'AWS_SECRET_ACCESS_KEY'
   }
   config.fog_directory = 'AWS_FOG_DIRECTORY' # bucket name
 end

--- a/spec/support/carrier_wave_config.rb
+++ b/spec/support/carrier_wave_config.rb
@@ -4,7 +4,8 @@ CarrierWave.configure do |config|
   config.fog_credentials = {
     :provider               => 'AWS',
     :aws_access_key_id      => 'AWS_ACCESS_KEY_ID',
-    :aws_secret_access_key  => 'AWS_SECRET_ACCESS_KEY'
+    :aws_secret_access_key  => 'AWS_SECRET_ACCESS_KEY',
+    :region                 => 'eu-east-1'
   }
   config.fog_directory = 'AWS_FOG_DIRECTORY' # bucket name
 end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -287,6 +287,7 @@ describe CarrierWaveDirect::Uploader do
   end
 
   # http://aws.amazon.com/articles/1434?_encoding=UTF8
+  #http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html
   describe "#policy" do
     def decoded_policy(options = {})
       instance = options.delete(:subject) || subject
@@ -464,11 +465,22 @@ describe CarrierWaveDirect::Uploader do
       expect(subject.signature).to_not include("\n")
     end
 
-    it "should return a base64 encoded 'sha1' hash of the secret key and policy document" do
-      expect(Base64.decode64(subject.signature)).to eq OpenSSL::HMAC.digest(
-        OpenSSL::Digest.new('sha1'),
-        subject.aws_secret_access_key, subject.policy
+    it "should return a HMAC hexdigest encoded 'sha256' hash of the secret key and policy document" do
+      expect(subject.signature).to eq OpenSSL::HMAC.hexdigest(
+        OpenSSL::Digest.new('sha256'),
+        subject.send(:signing_key), subject.policy
       )
+    end
+  end
+  #http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html
+  describe "#signature_key" do
+    it "should include correct signature_key elements" do
+      kDate    = OpenSSL::HMAC.digest('sha256', "AWS4" + subject.aws_secret_access_key, Time.now.utc.strftime("%Y%m%d"))
+      kRegion  = OpenSSL::HMAC.digest('sha256', kDate, subject.region)
+      kService = OpenSSL::HMAC.digest('sha256', kRegion, 's3')
+      kSigning = OpenSSL::HMAC.digest('sha256', kService, "aws4_request")
+
+      expect(subject.send(:signing_key)).to eq (kSigning)
     end
   end
 


### PR DESCRIPTION
fixes #183

Based on http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html
and https://github.com/RobotsAndPencils/s3_direct_upload