### PR TITLE
Allows the policy method to accept a block

### DIFF
--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -29,12 +29,12 @@ module CarrierWaveDirect
       fog_public ? 'public-read' : 'private'
     end
 
-    def policy(options = {})
+    def policy(options = {}, &block)
       options[:expiration] ||= upload_expiration
       options[:min_file_size] ||= min_file_size
       options[:max_file_size] ||= max_file_size
 
-      @policy ||= generate_policy(options)
+      @policy ||= generate_policy(options, &block)
     end
 
     def clear_policy!
@@ -148,6 +148,8 @@ module CarrierWaveDirect
       end
 
       conditions << ["content-length-range", options[:min_file_size], options[:max_file_size]]
+
+      yield conditions if block_given?
 
       Base64.encode64(
         {


### PR DESCRIPTION
The policy generation method now accepts a block and yields the conditions hash in order to add custom
rules.

The use case for this is to enable server-side encryption on amazon S3. 

[AWS documentation](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html)

When POSTing directly to S3, you need to include a config value in the form object `x-amz-server-side​-encryption' 

If you do that the POST will be rejected because the policy document doesn't match the same parameters that are being send and it will throw an extra parameter error. 

I've added a yield on the conditions so that I can just muck with them however I see fit.

I've forked the gem and the changes work perfect for my needs, I'm willing to make some modifications if you need me to but I'd like to get this contributed to the library so that we do not have to maintain our own fork. 

Thanks for the great library and let me know if I can be of any further help, I look forward to your feedback 

Cheers :beers:

