### PR TITLE
Fix for Capybara 2.7; Rack driver now considers hidden fields invisible

### DIFF
--- a/carrierwave_direct.gemspec
+++ b/carrierwave_direct.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "carrierwave"
   s.add_dependency "uuidtools"
-  s.add_dependency "fog"
+  s.add_dependency "fog-aws"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "timecop"

--- a/carrierwave_direct.gemspec
+++ b/carrierwave_direct.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "carrierwave_direct"
 
   s.add_dependency "carrierwave"
-  s.add_dependency "uuidtools"
   s.add_dependency "fog-aws"
 
   s.add_development_dependency "rspec"

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "carrierwave"
-gem "uuidtools"
 gem "fog"
 
 group :test do

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "carrierwave"
-gem "uuidtools"
 gem "fog"
 
 group :test do

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "carrierwave"
-gem "uuidtools"
 gem "fog"
 
 group :test do

--- a/lib/carrierwave_direct.rb
+++ b/lib/carrierwave_direct.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require "carrierwave"
-require "uuidtools"
 require "fog/aws"
 
 module CarrierWaveDirect

--- a/lib/carrierwave_direct.rb
+++ b/lib/carrierwave_direct.rb
@@ -2,7 +2,7 @@
 
 require "carrierwave"
 require "uuidtools"
-require "fog"
+require "fog/aws"
 
 module CarrierWaveDirect
 

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -74,7 +74,7 @@ module CarrierWaveDirect
     end
 
     def guid
-      UUIDTools::UUID.random_create
+      SecureRandom.uuid
     end
 
     def has_key?

--- a/spec/support/view_helpers.rb
+++ b/spec/support/view_helpers.rb
@@ -10,7 +10,7 @@ module ViewHelpers
   end
 
   def have_parent_selector(options = {})
-    have_selector(:xpath, parent_selector_xpath, options)
+    have_selector(:xpath, parent_selector_xpath, options.merge(visible: false))
   end
 
   def parent_selector_xpath


### PR DESCRIPTION
Fresh bundle install included Capybara 2.7; form_builder specs failed because latest Capybara Rack driver does not find hidden fields by default.