### PR TITLE
Validations not enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ If your upload was successful then you will be redirected to the `success_action
 
 The `key` is the most important piece of information as we can use it for validating the file extension, downloading the file from S3, processing it and re-uploading it.
 
-If you're using ActiveRecord, CarrierWaveDirect will by default validate the file extension based off your `extension_white_list` in your uploader. See the [CarrierWave readme](https://github.com/jnicklas/carrierwave) for more info. You can then use the helper `filename_valid?` to check if the filename is valid. e.g.
+If you're using ActiveRecord, CarrierWaveDirect can validate the file extension based off your `extension_white_list` in your uploader. See the [CarrierWave readme](https://github.com/jnicklas/carrierwave) and the Validations section below for more info. You can then use the helper `filename_valid?` to check if the filename is valid. e.g.
 
 ```ruby
 class UsersController < ApplicationController
@@ -375,37 +375,37 @@ The methods `has_avatar_upload?`, `remote_avatar_net_url` and `has_remote_avatar
 
 ## Validations
 
-Along with validating the extension of the filename, CarrierWaveDirect also gives you some other validations:
+In addition to validating the extension of the filename, CarrierWaveDirect also gives you some additional optional validations. All validations below are turned off by default, and can be enabled globally in your CarrierWave config, or within individual models as shown below:
 
 ```ruby
 validates :avatar :is_uploaded => true
 ```
 
-Validates that your mounted model has an avatar uploaded from file or specified by remote url. It does not check that an your mounted model actually has a valid avatar after the download has taken place. Turned *off* by default
+Validates that your mounted model has an avatar uploaded from file or specified by remote url. It does not check that an your mounted model actually has a valid avatar after the download has taken place.
 
 ```ruby
 validates :avatar, :is_attached => true
 ```
 
-Validates that your mounted model has an avatar attached. This checks whether there is an actual avatar attached to the mounted model after downloading. Turned *off* by default
+Validates that your mounted model has an avatar attached. This checks whether there is an actual avatar attached to the mounted model after downloading.
 
 ```ruby
 validates :avatar, :filename_uniqueness => true
 ```
 
-Validates that the filename in the database is unique. Turned *on* by default
+Validates that the filename in the database is unique.
 
 ```ruby
 validates :avatar, :filename_format => true
 ```
 
-Validates that the uploaded filename is valid. As well as validating the extension against the `extension_white_list` it also validates that the `upload_dir` is correct. Turned *on* by default
+Validates that the uploaded filename is valid. As well as validating the extension against the `extension_white_list` it also validates that the `upload_dir` is correct.
 
 ```ruby
 validates :avatar, :remote_net_url_format => true
 ```
 
-Validates that the remote net url is valid. As well as validating the extension against the `extension_white_list` it also validates that url is valid and has only the schemes specified in the `url_scheme_whitelist`. Turned *on* by default
+Validates that the remote net url is valid. As well as validating the extension against the `extension_white_list` it also validates that url is valid and has only the schemes specified in the `url_scheme_whitelist`.
 
 ## Configuration
 
@@ -415,9 +415,9 @@ As well as the built in validations CarrierWaveDirect provides, some validations
 CarrierWave.configure do |config|
   config.validate_is_attached = true             # defaults to false
   config.validate_is_uploaded = true             # defaults to false
-  config.validate_unique_filename = false        # defaults to true
-  config.validate_filename_format = false        # defaults to true
-  config.validate_remote_net_url_format = false  # defaults to true
+  config.validate_unique_filename = true         # defaults to false
+  config.validate_filename_format = true         # defaults to false
+  config.validate_remote_net_url_format = true   # defaults to false
 
   config.min_file_size             = 5.kilobytes  # defaults to 1.byte
   config.max_file_size             = 10.megabytes # defaults to 5.megabytes

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -163,6 +163,7 @@ module CarrierWaveDirect
       conditions << {'X-Amz-Algorithm' => algorithm}
       conditions << {'X-Amz-Credential' => credential}
       conditions << {'X-Amz-Date' => date}
+      conditions << {'X-Amz-Server-Side-Encryption' => 'AES256'} if options[:encrypt]
       conditions << ["starts-with", "$Content-Type", ""] if will_include_content_type
       conditions << {"bucket" => fog_directory}
       conditions << {"acl" => acl}

--- a/lib/carrierwave_direct/uploader/configuration.rb
+++ b/lib/carrierwave_direct/uploader/configuration.rb
@@ -30,9 +30,9 @@ module CarrierWaveDirect
           configure do |config|
             config.validate_is_attached = false
             config.validate_is_uploaded = false
-            config.validate_unique_filename = true
-            config.validate_filename_format = true
-            config.validate_remote_net_url_format = true
+            config.validate_unique_filename = false
+            config.validate_filename_format = false
+            config.validate_remote_net_url_format = false
 
             config.min_file_size = 1
             config.max_file_size = 5242880

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -160,160 +160,207 @@ describe CarrierWaveDirect::ActiveRecord do
     end
 
     describe ".validates_filename_uniqueness_of" do
-      it "should be turned on by default" do
-        party_class.should_receive(:validates_filename_uniqueness_of).with(:video, on: :create)
+      it "should be turned off by default" do
+        party_class.should_not_receive(:validates_filename_uniqueness_of).with(:video, on: :create)
         mount_uploader
       end
 
-      context "mount_on: option is used" do
-        let(:dance) { Dance.new }
-
-        before { Dance.mount_uploader(:non_existing_column, DirectUploader, mount_on: :location)    }
-        before { dance.non_existing_column_key = sample_key}
-
-        it "uses the column it's mounted on for checking uniqueness" do
-          expect { dance.valid? }.to_not raise_error
-        end
-      end
-
-      context "another Party with a duplicate video filename" do
+      context "is turned on in the configuration" do
         before do
-          subject.video.key = sample_key
-          subject.save
+          DirectUploader.validate_unique_filename = true
         end
 
-        let(:another_party) do
-          another_party = party_class.new
-          another_party.video.key = subject.video.key
-          another_party
-        end
-
-        it "should not be valid" do
-          another_party.should_not be_valid
-        end
-
-        it "should use I18n for the error messages" do
-          another_party.valid?
-          another_party.errors[:video].should == [I18n.t("errors.messages.carrierwave_direct_filename_taken")]
-        end
-      end
-
-      context "is turned off in the configuration" do
-        before do
-          DirectUploader.validate_unique_filename = false
-        end
-
-        it "should not validate the filename uniqueness" do
-          party_class.should_not_receive(:validates_filename_uniqueness_of)
+        it "should validate the filename uniqueness" do
+          party_class.should_receive(:validates_filename_uniqueness_of)
           mount_uploader
+        end
+      end
+
+      context "is on" do
+        before do
+          party_class.validates_filename_uniqueness_of :video, on: :create
+        end
+
+        context "mount_on: option is used" do
+          let(:dance) { Dance.new }
+
+          before { Dance.mount_uploader(:non_existing_column, DirectUploader, mount_on: :location)    }
+          before { dance.non_existing_column_key = sample_key }
+
+          it "uses the column it's mounted on for checking uniqueness" do
+            expect { dance.valid? }.to_not raise_error
+          end
+        end
+
+        context "another Party with a duplicate video filename" do
+          before do
+            subject.video.key = sample_key
+            subject.save
+          end
+
+          let(:another_party) do
+            another_party = party_class.new
+            another_party.video.key = subject.video.key
+            another_party
+          end
+
+          it "should not be valid" do
+            another_party.should_not be_valid
+          end
+
+          it "should use I18n for the error messages" do
+            another_party.valid?
+            another_party.errors[:video].should == [I18n.t("errors.messages.carrierwave_direct_filename_taken")]
+          end
         end
       end
     end
 
     describe ".validates_filename_format_of" do
-      it "should be turned on by default" do
-        party_class.should_receive(:validates_filename_format_of).with(:video, on: :create)
+      it "should be turned off by default" do
+        party_class.should_not_receive(:validates_filename_format_of).with(:video, on: :create)
         mount_uploader
-      end
-
-      context "where the file upload is" do
-        context "nil" do
-          before do
-            subject.video_key = nil
-          end
-
-          it "should be valid" do
-            subject.should be_valid
-          end
-        end
-
-        context "blank" do
-          before do
-            subject.video_key = ""
-          end
-
-          it "should be valid" do
-            subject.should be_valid
-          end
-        end
-      end
-
-      context "where the uploader has an extension white list" do
-        before do
-          subject.video.stub(:extension_white_list).and_return(%w{avi mp4})
-        end
-
-        context "and the uploaded file's extension is included in the list" do
-          before do
-            subject.video_key = sample_key(:extension => "avi")
-          end
-
-          it "should be valid" do
-            subject.should be_valid
-          end
-        end
-
-        context "but uploaded file's extension is not included in the list" do
-          before do
-            subject.video_key = sample_key(:extension => "mp3")
-          end
-
-          it_should_behave_like "an invalid filename"
-
-          it "should include the white listed extensions in the error message" do
-            subject.valid?
-            subject.errors[:video].first.should include("avi and mp4")
-          end
-        end
-
-        context "and the video's key does not contain a guid" do
-          before do
-            subject.video.key = sample_key(:valid => false)
-          end
-
-          it_should_behave_like "an invalid filename"
-        end
       end
 
       context "is turned off in the configuration" do
         before do
-          DirectUploader.validate_filename_format = false
+          DirectUploader.validate_filename_format = true
         end
 
-        it "should not validate the filename format" do
-          party_class.should_not_receive(:validates_filename_format_of)
+        it "should validate the filename format" do
+          party_class.should_receive(:validates_filename_format_of)
           mount_uploader
+        end
+      end
+
+      context "is on" do
+        before do
+          party_class.validates_filename_format_of :video, on: :create
+        end
+
+        context "where the file upload is" do
+          context "nil" do
+            before do
+              subject.video_key = nil
+            end
+
+            it "should be valid" do
+              subject.should be_valid
+            end
+          end
+
+          context "blank" do
+            before do
+              subject.video_key = ""
+            end
+
+            it "should be valid" do
+              subject.should be_valid
+            end
+          end
+        end
+
+        context "where the uploader has an extension white list" do
+          before do
+            subject.video.stub(:extension_white_list).and_return(%w{avi mp4})
+          end
+
+          context "and the uploaded file's extension is included in the list" do
+            before do
+              subject.video_key = sample_key(:extension => "avi")
+            end
+
+            it "should be valid" do
+              subject.should be_valid
+            end
+          end
+
+          context "but uploaded file's extension is not included in the list" do
+            before do
+              subject.video_key = sample_key(:extension => "mp3")
+            end
+
+            it_should_behave_like "an invalid filename"
+
+            it "should include the white listed extensions in the error message" do
+              subject.valid?
+              subject.errors[:video].first.should include("avi and mp4")
+            end
+          end
+
+          context "and the video's key does not contain a guid" do
+            before do
+              subject.video.key = sample_key(:valid => false)
+            end
+
+            it_should_behave_like "an invalid filename"
+          end
         end
       end
     end
 
     describe ".validates_remote_net_url_format_of" do
-      it "should be turned on by default" do
-        party_class.should_receive(:validates_remote_net_url_format_of).with(:video, on: :create)
+      it "should be turned off by default" do
+        party_class.should_not_receive(:validates_remote_net_url_format_of).with(:video, on: :create)
         mount_uploader
       end
 
-      context "with an invalid remote image net url" do
+      context "is turned on in the configuration" do
+        before do
+          DirectUploader.validate_remote_net_url_format = true
+        end
 
-        context "on create" do
-          context "where the uploader has an extension white list" do
-            before do
-              subject.video.stub(:extension_white_list).and_return(%w{avi mp4})
-            end
+        it "should validate the format of the remote net url" do
+          party_class.should_receive(:validates_remote_net_url_format_of)
+          mount_uploader
+        end
+      end
 
-            context "and the url's extension is included in the list" do
+      context "is on" do
+        before do
+          party_class.validates_remote_net_url_format_of :video, on: :create
+        end
+        context "with an invalid remote image net url" do
+
+          context "on create" do
+            context "where the uploader has an extension white list" do
               before do
-                subject.remote_video_net_url = "http://example.com/some_video.mp4"
+                subject.video.stub(:extension_white_list).and_return(%w{avi mp4})
               end
 
-              it "should be valid" do
-                subject.should be_valid
+              context "and the url's extension is included in the list" do
+                before do
+                  subject.remote_video_net_url = "http://example.com/some_video.mp4"
+                end
+
+                it "should be valid" do
+                  subject.should be_valid
+                end
+              end
+
+              context "but the url's extension is not included in the list" do
+                before do
+                  subject.remote_video_net_url = "http://example.com/some_video.mp3"
+                end
+
+                it "should not be valid" do
+                  subject.should_not be_valid
+                end
+
+                it_should_behave_like "a remote net url i18n error message" do
+                  let(:i18n_options) { {:extension_white_list => %w{avi mp4} } }
+                end
+
+                it "should include the white listed extensions in the error message" do
+                  subject.valid?
+                  subject.errors[:remote_video_net_url].first.should include("avi and mp4")
+                end
               end
             end
 
-            context "but the url's extension is not included in the list" do
+            context "where the url is invalid" do
               before do
-                subject.remote_video_net_url = "http://example.com/some_video.mp3"
+                subject.remote_video_net_url = "http$://example.com/some_video.mp4"
               end
 
               it "should not be valid" do
@@ -321,108 +368,78 @@ describe CarrierWaveDirect::ActiveRecord do
               end
 
               it_should_behave_like "a remote net url i18n error message" do
-                let(:i18n_options) { {:extension_white_list => %w{avi mp4} } }
+                let(:i18n_options) { nil }
+              end
+            end
+
+            context "where the url is" do
+              context "nil" do
+                before do
+                  subject.remote_video_net_url = nil
+                end
+
+                it "should be valid" do
+                  subject.should be_valid
+                end
               end
 
-              it "should include the white listed extensions in the error message" do
-                subject.valid?
-                subject.errors[:remote_video_net_url].first.should include("avi and mp4")
+              context "blank" do
+                before do
+                  subject.remote_video_net_url = ""
+                end
+
+                it "should be valid" do
+                  subject.should be_valid
+                end
+              end
+            end
+
+            context "where the uploader specifies valid url schemes" do
+              before do
+                subject.video.stub(:url_scheme_white_list).and_return(%w{http https})
+              end
+
+              context "and the url's scheme is included in the list" do
+                before do
+                  subject.remote_video_net_url = "https://example.com/some_video.mp3"
+                end
+
+                it "should be valid" do
+                  subject.should be_valid
+                end
+              end
+
+              context "but the url's scheme is not included in the list" do
+                before do
+                  subject.remote_video_net_url = "ftp://example.com/some_video.mp3"
+                end
+
+                it "should not be valid" do
+                  subject.should_not be_valid
+                end
+
+                it_should_behave_like "a remote net url i18n error message" do
+                  let(:i18n_options) { {:url_scheme_white_list => %w{http https} } }
+                end
+
+                it "should include the white listed url schemes in the error message" do
+                  subject.valid?
+                  subject.errors[:remote_video_net_url].first.should include("http and https")
+                end
               end
             end
           end
 
-          context "where the url is invalid" do
+          context "on update" do
             before do
               subject.remote_video_net_url = "http$://example.com/some_video.mp4"
             end
 
-            it "should not be valid" do
-              subject.should_not be_valid
-            end
-
-            it_should_behave_like "a remote net url i18n error message" do
-              let(:i18n_options) { nil }
+            it "should be valid" do
+              subject.save(:validate => false)
+              subject.should be_valid
             end
           end
-
-          context "where the url is" do
-            context "nil" do
-              before do
-                subject.remote_video_net_url = nil
-              end
-
-              it "should be valid" do
-                subject.should be_valid
-              end
-            end
-
-            context "blank" do
-              before do
-                subject.remote_video_net_url = ""
-              end
-
-              it "should be valid" do
-                subject.should be_valid
-              end
-            end
-          end
-
-          context "where the uploader specifies valid url schemes" do
-            before do
-              subject.video.stub(:url_scheme_white_list).and_return(%w{http https})
-            end
-
-            context "and the url's scheme is included in the list" do
-              before do
-                subject.remote_video_net_url = "https://example.com/some_video.mp3"
-              end
-
-              it "should be valid" do
-                subject.should be_valid
-              end
-            end
-
-            context "but the url's scheme is not included in the list" do
-              before do
-                subject.remote_video_net_url = "ftp://example.com/some_video.mp3"
-              end
-
-              it "should not be valid" do
-                subject.should_not be_valid
-              end
-
-              it_should_behave_like "a remote net url i18n error message" do
-                let(:i18n_options) { {:url_scheme_white_list => %w{http https} } }
-              end
-
-              it "should include the white listed url schemes in the error message" do
-                subject.valid?
-                subject.errors[:remote_video_net_url].first.should include("http and https")
-              end
-            end
-          end
-        end
-
-        context "on update" do
-          before do
-            subject.remote_video_net_url = "http$://example.com/some_video.mp4"
-          end
-
-          it "should be valid" do
-            subject.save(:validate => false)
-            subject.should be_valid
-          end
-        end
-      end
-
-      context "is turned off in the configuration" do
-        before do
-          DirectUploader.validate_remote_net_url_format = false
-        end
-
-        it "should not validate the format of the remote net url" do
-          party_class.should_not_receive(:validates_remote_net_url_format_of)
-          mount_uploader
         end
       end
     end
@@ -571,8 +588,11 @@ describe CarrierWaveDirect::ActiveRecord do
           it_should_behave_like "having empty errors"
         end
 
-        context "with an invalid filename" do
-          before { subject.video_key = sample_key(:model_class => subject.class, :valid => false) }
+        context "with an invalid filename and filename validations enabled" do
+          before do
+            party_class.validates_filename_format_of :video, on: :create
+            subject.video_key = sample_key(:model_class => subject.class, :valid => false)
+          end
 
           it "should be false" do
             subject.filename_valid?.should be false

--- a/spec/uploader/configuration_spec.rb
+++ b/spec/uploader/configuration_spec.rb
@@ -19,12 +19,12 @@ describe CarrierWaveDirect::Uploader::Configuration do
       expect(subject.validate_is_uploaded).to be false
     end
 
-    it "return true for validate_unique_filename" do
-      expect(subject.validate_unique_filename).to be true
+    it "return false for validate_unique_filename" do
+      expect(subject.validate_unique_filename).to be false
     end
 
-    it "returns true for validate_remote_net_url_format" do
-      expect(subject.validate_remote_net_url_format).to be true
+    it "returns false for validate_remote_net_url_format" do
+      expect(subject.validate_remote_net_url_format).to be false
     end
 
     it "has upload_expiration of 10 hours" do


### PR DESCRIPTION
@p8 Here is a PR that changes the validations so they are all disabled by default.

I think I hit all the Readme docs as well to note that validations are optional but can be enabled either globally (via the config file) or in individual models when mounting the uploader.

Again, my argument for this is that version 0.0.15 did not have validations. So code running & tested under that version should not break due to the presence of new default validations during an upgrade. But wanted your take on it as well so I've done it on my branch first.
