### PR TITLE
depricated extension_whitelist change to extension_allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ If your upload was successful then you will be redirected to the `success_action
 
 The `key` is the most important piece of information as we can use it for validating the file extension, downloading the file from S3, processing it and re-uploading it.
 
-If you're using ActiveRecord, CarrierWaveDirect will by default validate the file extension based off your `extension_whitelist` in your uploader. See the [CarrierWave readme](https://github.com/jnicklas/carrierwave) for more info. You can then use the helper `filename_valid?` to check if the filename is valid. e.g.
+If you're using ActiveRecord, CarrierWaveDirect will by default validate the file extension based off your `extension_allowlist` in your uploader. See the [CarrierWave readme](https://github.com/jnicklas/carrierwave) for more info. You can then use the helper `filename_valid?` to check if the filename is valid. e.g.
 
 ```ruby
 class UsersController < ApplicationController
@@ -404,13 +404,13 @@ Validates that the filename in the database is unique. Turned *on* by default
 validates :avatar, :filename_format => true
 ```
 
-Validates that the uploaded filename is valid. As well as validating the extension against the `extension_whitelist` it also validates that the `upload_dir` is correct. Turned *on* by default
+Validates that the uploaded filename is valid. As well as validating the extension against the `extension_allowlist` it also validates that the `upload_dir` is correct. Turned *on* by default
 
 ```ruby
 validates :avatar, :remote_net_url_format => true
 ```
 
-Validates that the remote net url is valid. As well as validating the extension against the `extension_whitelist` it also validates that url is valid and has only the schemes specified in the `url_scheme_whitelist`. Turned *on* by default
+Validates that the remote net url is valid. As well as validating the extension against the `extension_allowlist` it also validates that url is valid and has only the schemes specified in the `url_scheme_whitelist`. Turned *on* by default
 
 ## Configuration
 
@@ -527,7 +527,7 @@ Factory.define :user |f|
 end
 ```
 
-This will return a valid key based off your `upload_dir` and your `extension_whitelist`
+This will return a valid key based off your `upload_dir` and your `extension_allowlist`
 
 ### Faking a background download
 

--- a/lib/carrierwave_direct/test/helpers.rb
+++ b/lib/carrierwave_direct/test/helpers.rb
@@ -18,7 +18,7 @@ module CarrierWaveDirect
           options[:filename] = filename_parts.join(".")
         end
         options[:filename] ||= "filename"
-        valid_extension = uploader.extension_whitelist.first if uploader.extension_whitelist
+        valid_extension = uploader.extension_allowlist.first if uploader.extension_allowlist
         options[:extension] = options[:extension] ? options[:extension].gsub(".", "") : (valid_extension || "extension")
         key = options[:base].split("/")
         key.pop

--- a/lib/carrierwave_direct/uploader.rb
+++ b/lib/carrierwave_direct/uploader.rb
@@ -101,7 +101,7 @@ module CarrierWaveDirect
     end
 
     def extension_regexp
-      allowed_file_types = extension_whitelist
+      allowed_file_types = extension_allowlist
       extension_regexp = allowed_file_types.present? && allowed_file_types.any? ?  "(#{allowed_file_types.join("|")})" : "\\w+"
     end
 

--- a/lib/carrierwave_direct/validations/active_model.rb
+++ b/lib/carrierwave_direct/validations/active_model.rb
@@ -23,7 +23,7 @@ module CarrierWaveDirect
       class FilenameFormatValidator < ::ActiveModel::EachValidator
         def validate_each(record, attribute, value)
           if record.send("has_#{attribute}_upload?") && record.send("#{attribute}_key") !~ record.send(attribute).key_regexp
-            extensions = record.send(attribute).extension_whitelist
+            extensions = record.send(attribute).extension_allowlist
             message = I18n.t("errors.messages.carrierwave_direct_filename_invalid")
 
             if extensions.present?
@@ -43,7 +43,7 @@ module CarrierWaveDirect
             url_scheme_white_list = uploader.url_scheme_white_list
 
             if (remote_net_url !~ URI.regexp(url_scheme_white_list) || remote_net_url !~ /#{uploader.extension_regexp}\z/)
-              extensions = uploader.extension_whitelist
+              extensions = uploader.extension_allowlist
 
               message = I18n.t("errors.messages.carrierwave_direct_filename_invalid")
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -104,8 +104,8 @@ describe CarrierWaveDirect::ActiveRecord do
         messages = I18n.t("errors.messages.carrierwave_direct_filename_invalid")
 
         if i18n_options
-          if i18n_options[:extension_whitelist]
-            extensions = i18n_options[:extension_whitelist].to_sentence
+          if i18n_options[:extension_allowlist]
+            extensions = i18n_options[:extension_allowlist].to_sentence
             messages += I18n.t("errors.messages.carrierwave_direct_allowed_extensions", :extensions => extensions)
           end
 
@@ -244,7 +244,7 @@ describe CarrierWaveDirect::ActiveRecord do
 
       context "where the uploader has an extension white list" do
         before do
-          subject.video.stub(:extension_whitelist).and_return(%w{avi mp4})
+          subject.video.stub(:extension_allowlist).and_return(%w{avi mp4})
         end
 
         context "and the uploaded file's extension is included in the list" do
@@ -302,7 +302,7 @@ describe CarrierWaveDirect::ActiveRecord do
         context "on create" do
           context "where the uploader has an extension white list" do
             before do
-              subject.video.stub(:extension_whitelist).and_return(%w{avi mp4})
+              subject.video.stub(:extension_allowlist).and_return(%w{avi mp4})
             end
 
             context "and the url's extension is included in the list" do
@@ -325,7 +325,7 @@ describe CarrierWaveDirect::ActiveRecord do
               end
 
               it_should_behave_like "a remote net url i18n error message" do
-                let(:i18n_options) { {:extension_whitelist => %w{avi mp4} } }
+                let(:i18n_options) { {:extension_allowlist => %w{avi mp4} } }
               end
 
               it "should include the white listed extensions in the error message" do

--- a/spec/test/helpers_spec.rb
+++ b/spec/test/helpers_spec.rb
@@ -19,7 +19,7 @@ describe CarrierWaveDirect::Test::Helpers do
 
         context "['exe', 'bmp']" do
           before do
-            allow(direct_uploader).to receive(:extension_whitelist).and_return(%w{exe bmp})
+            allow(direct_uploader).to receive(:extension_allowlist).and_return(%w{exe bmp})
           end
 
           it "should return '*/guid/filename.exe'" do
@@ -29,7 +29,7 @@ describe CarrierWaveDirect::Test::Helpers do
 
         context "[]" do
           before do
-            allow(direct_uploader).to receive(:extension_whitelist).and_return([])
+            allow(direct_uploader).to receive(:extension_allowlist).and_return([])
           end
 
           it_should_behave_like "returning the default extension"
@@ -37,7 +37,7 @@ describe CarrierWaveDirect::Test::Helpers do
 
         context "nil" do
           before do
-            allow(direct_uploader).to receive(:extension_whitelist).and_return(nil)
+            allow(direct_uploader).to receive(:extension_allowlist).and_return(nil)
           end
 
           it_should_behave_like "returning the default extension"

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -145,26 +145,26 @@ describe CarrierWaveDirect::Uploader do
       expect(subject.extension_regexp).to be_a(String)
     end
 
-    context "where #extension_whitelist returns nil" do
+    context "where #extension_allowlist returns nil" do
       before do
-        allow(subject).to receive(:extension_whitelist).and_return(nil)
+        allow(subject).to receive(:extension_allowlist).and_return(nil)
       end
 
       it_should_behave_like "a globally allowed file extension"
     end
 
-    context "where #extension_whitelist returns []" do
+    context "where #extension_allowlist returns []" do
       before do
-        allow(subject).to receive(:extension_whitelist).and_return([])
+        allow(subject).to receive(:extension_allowlist).and_return([])
       end
 
       it_should_behave_like "a globally allowed file extension"
     end
 
-    context "where #extension_whitelist returns ['exe', 'bmp']" do
+    context "where #extension_allowlist returns ['exe', 'bmp']" do
 
       before do
-        allow(subject).to receive(:extension_whitelist).and_return(%w{exe bmp})
+        allow(subject).to receive(:extension_allowlist).and_return(%w{exe bmp})
       end
 
       it "should return '(exe|bmp)'" do


### PR DESCRIPTION
Carrierwave 2.2.1 has move to extension_allowlist since it's depricated. So in order to this gem to work with the newest carrierwave gem we had to rename extension_whitelist to extension_allowlist.